### PR TITLE
feat(form): radio input with radio group component

### DIFF
--- a/apps/docs/src/app/app.tsx
+++ b/apps/docs/src/app/app.tsx
@@ -193,9 +193,9 @@ export function App() {
         id: 'radio-1',
         name: 'fol',
         defaultValue: '2',
-        radioInputsList: [
-          { label: 'radio-num-1', value: '1' },
-          { label: 'radio-num-2', value: '2' },
+        options: [
+          { name: 'radio-num-1', value: 'value 1', id: '1' },
+          { name: 'radio-num-2', value: 'value 2', id: '2' },
         ],
       },
     },
@@ -245,7 +245,7 @@ export function App() {
         // multiple: true,
         defaultValue: '',
         inputLabelProps: {
-          children: "input label"
+          children: 'input label',
         },
         options: [
           { name: 'first', id: '1' },

--- a/apps/docs/src/app/app.tsx
+++ b/apps/docs/src/app/app.tsx
@@ -163,6 +163,21 @@ export function App() {
         },
       },
     },
+    {
+      id: 'form-radio-1',
+      groupType: 'form',
+      type: 'radio',
+      props: {
+        formId: '18',
+        id: 'radio-1',
+        name: 'fol',
+        defaultValue: '2',
+        radioInputsList: [
+          { label: 'radio-num-1', value: '1' },
+          { label: 'radio-num-2', value: '2' },
+        ],
+      },
+    },
   ];
 
   return (

--- a/packages/core/src/modules/form/src/components/fields/radio/radio.tsx
+++ b/packages/core/src/modules/form/src/components/fields/radio/radio.tsx
@@ -1,0 +1,20 @@
+import { FC } from 'react';
+
+import { FormControlLabel, Radio as MuiRadio } from '@mui/material';
+
+import { RadioProps } from './radio.types';
+
+import useRadio from './useRadio';
+
+const Radio: FC<RadioProps> = (props) => {
+  const { getFormControlLabelProps, getRadioInputProps } = useRadio(props);
+
+  return (
+    <FormControlLabel
+      {...getFormControlLabelProps()}
+      control={<MuiRadio {...getRadioInputProps()} />}
+    />
+  );
+};
+
+export default Radio;

--- a/packages/core/src/modules/form/src/components/fields/radio/radio.types.ts
+++ b/packages/core/src/modules/form/src/components/fields/radio/radio.types.ts
@@ -7,12 +7,13 @@ import {
 import { Api } from '@mui-builder/types/api.types';
 import { Script } from '@mui-builder/types/script.types';
 
-import { Dependencies, FormId, Id } from '../../../types/public.types';
+import { Dependencies, FormId, Id, Option } from '../../../types/public.types';
 import { Rule } from '../../../types/validation.types';
 
-export type RadioProps = Omit<FormControlLabelProps, 'control'> & {
-  radioInputProps?: MuiRadioProps;
-};
+export type RadioProps = Omit<FormControlLabelProps, 'control' | 'label'> &
+  Option & {
+    radioInputProps?: MuiRadioProps;
+  };
 
 export type RadioGroupProps = MuiRadioGroupProps & {
   id: Id;
@@ -23,5 +24,5 @@ export type RadioGroupProps = MuiRadioGroupProps & {
   api?: Api;
   rule?: Rule;
   show?: boolean;
-  radioInputsList: RadioProps[];
+  options: RadioProps[];
 };

--- a/packages/core/src/modules/form/src/components/fields/radio/radio.types.ts
+++ b/packages/core/src/modules/form/src/components/fields/radio/radio.types.ts
@@ -1,0 +1,27 @@
+import {
+  FormControlLabelProps,
+  RadioGroupProps as MuiRadioGroupProps,
+  RadioProps as MuiRadioProps,
+} from '@mui/material';
+
+import { Api } from '@mui-builder/types/api.types';
+import { Script } from '@mui-builder/types/script.types';
+
+import { Dependesies, FormId, Id } from '../../../types/public.types';
+import { Rule } from '../../../types/validation.types';
+
+export type RadioProps = Omit<FormControlLabelProps, 'control'> & {
+  radioInputProps?: MuiRadioProps;
+};
+
+export type RadioGroupProps = MuiRadioGroupProps & {
+  id: Id;
+  formId: FormId;
+  script?: Script;
+  dependesies?: Dependesies;
+  propsController?: Record<string, any>;
+  api?: Api;
+  rule?: Rule;
+  show?: boolean;
+  radioInputsList: RadioProps[];
+};

--- a/packages/core/src/modules/form/src/components/fields/radio/radioGroup.tsx
+++ b/packages/core/src/modules/form/src/components/fields/radio/radioGroup.tsx
@@ -1,0 +1,22 @@
+import { FC } from 'react';
+
+import { RadioGroup as MuiRadioGroup } from '@mui/material';
+
+import { RadioGroupProps } from './radio.types';
+
+import Radio from './radio';
+import useRadioGroup from './useRadioGroup';
+
+const RadioGroup: FC<RadioGroupProps> = (props) => {
+  const { getRadioGroupProps, radioInputsList } = useRadioGroup(props);
+
+  return (
+    <MuiRadioGroup {...getRadioGroupProps()}>
+      {radioInputsList.map((radio) => (
+        <Radio key={radio.id} {...radio} />
+      ))}
+    </MuiRadioGroup>
+  );
+};
+
+export default RadioGroup;

--- a/packages/core/src/modules/form/src/components/fields/radio/radioGroup.tsx
+++ b/packages/core/src/modules/form/src/components/fields/radio/radioGroup.tsx
@@ -8,11 +8,11 @@ import Radio from './radio';
 import useRadioGroup from './useRadioGroup';
 
 const RadioGroup: FC<RadioGroupProps> = (props) => {
-  const { getRadioGroupProps, radioInputsList } = useRadioGroup(props);
+  const { getRadioGroupProps, options } = useRadioGroup(props);
 
   return (
     <MuiRadioGroup {...getRadioGroupProps()}>
-      {radioInputsList.map((radio) => (
+      {options.map((radio) => (
         <Radio key={radio.id} {...radio} />
       ))}
     </MuiRadioGroup>

--- a/packages/core/src/modules/form/src/components/fields/radio/useRadio.ts
+++ b/packages/core/src/modules/form/src/components/fields/radio/useRadio.ts
@@ -1,0 +1,13 @@
+import { RadioProps } from './radio.types';
+
+const useRadio = (props: RadioProps) => {
+  const { radioInputProps, ...restRadioProps } = props;
+
+  const getRadioInputProps = () => ({ ...radioInputProps });
+
+  const getFormControlLabelProps = () => ({ ...restRadioProps });
+
+  return { getRadioInputProps, getFormControlLabelProps };
+};
+
+export default useRadio;

--- a/packages/core/src/modules/form/src/components/fields/radio/useRadio.ts
+++ b/packages/core/src/modules/form/src/components/fields/radio/useRadio.ts
@@ -5,7 +5,7 @@ const useRadio = (props: RadioProps) => {
 
   const getRadioInputProps = () => ({ ...radioInputProps });
 
-  const getFormControlLabelProps = () => ({ ...restRadioProps });
+  const getFormControlLabelProps = () => ({ ...restRadioProps, label: restRadioProps.name });
 
   return { getRadioInputProps, getFormControlLabelProps };
 };

--- a/packages/core/src/modules/form/src/components/fields/radio/useRadioGroup.ts
+++ b/packages/core/src/modules/form/src/components/fields/radio/useRadioGroup.ts
@@ -20,7 +20,7 @@ const useRadioGroup = (props: RadioGroupProps) => {
     show = true,
     dependesies,
     defaultValue,
-    radioInputsList,
+    options,
     ...restRadioGroupProps
   } = props;
 
@@ -78,7 +78,7 @@ const useRadioGroup = (props: RadioGroupProps) => {
     ...newProps,
   });
 
-  return { getRadioGroupProps, radioInputsList };
+  return { getRadioGroupProps, options };
 };
 
 export default useRadioGroup;

--- a/packages/core/src/modules/form/src/components/fields/radio/useRadioGroup.ts
+++ b/packages/core/src/modules/form/src/components/fields/radio/useRadioGroup.ts
@@ -1,0 +1,84 @@
+import { useController, useWatch } from 'react-hook-form';
+
+import useQueryBuilder from '@mui-builder/utils/useQueryBuilder/useQueryBuilder';
+import UseScript from '@mui-builder/utils/useScript/useScript';
+
+import axios from 'axios';
+
+import { RadioGroupProps } from './radio.types';
+
+import useForms from '../../../hooks/useForms/useForms';
+import usePropsController from '../../../hooks/usePropsController/usePropsController';
+import useRule from '../../../hooks/useRule/useRule';
+
+const useRadioGroup = (props: RadioGroupProps) => {
+  const {
+    id,
+    api,
+    script,
+    formId,
+    show = true,
+    dependesies,
+    defaultValue,
+    radioInputsList,
+    ...restRadioGroupProps
+  } = props;
+
+  const { configs, queries } = api || {};
+
+  const { forms } = useForms();
+  const formMethod = forms?.[formId];
+
+  const { setProps, propsController } = usePropsController();
+  const newProps = propsController?.[id] || {};
+
+  useQueryBuilder({
+    apiInstance: axios,
+    apiConfigs: configs ?? {},
+    apiQuery: queries ?? {},
+    formMethod,
+    formId,
+    forms,
+  });
+
+  // Handle Wtach Fields
+  useWatch({
+    control: formMethod.control,
+    name: dependesies ?? [],
+  });
+
+  // Controller
+  const {
+    field,
+    formState: { errors },
+  } = useController({
+    name: id,
+    control: formMethod.control,
+    // disabled: restRadioGroupProps.disabled,
+    rules: useRule(restRadioGroupProps?.rule),
+    defaultValue,
+  });
+
+  const error = errors?.[id];
+
+  // Handle Script
+  const { scriptResult } = UseScript({
+    script,
+    formMethod,
+    forms,
+    formId,
+    setProps,
+  });
+
+  const getRadioGroupProps = () => ({
+    ...field,
+    ...restRadioGroupProps,
+    error,
+    ...scriptResult,
+    ...newProps,
+  });
+
+  return { getRadioGroupProps, radioInputsList };
+};
+
+export default useRadioGroup;

--- a/packages/core/src/modules/form/src/types/public.types.ts
+++ b/packages/core/src/modules/form/src/types/public.types.ts
@@ -1,6 +1,7 @@
 import { SkeletonOwnProps } from '@mui/material';
 
 import { SubmitFieldProps } from '../components/actions/submit/submit.types';
+import { RadioGroupProps } from '../components/fields/radio/radio.types';
 import { TextProps } from '../components/fields/text/text.types';
 import { Form } from '../hooks/useForms/useForms.types';
 
@@ -10,9 +11,9 @@ export type Forms = Record<string, Form>;
 
 export type Id = string;
 
-export type FormTypes = 'field-text' | 'action-submit';
+export type FormTypes = 'field-text' | 'action-submit' | 'radio';
 
-export type FieldProps = TextProps | SubmitFieldProps;
+export type FieldProps = TextProps | SubmitFieldProps | RadioGroupProps;
 
 export type Dependesies = string[];
 

--- a/packages/core/src/modules/form/src/utils/selector/formSelector.tsx
+++ b/packages/core/src/modules/form/src/utils/selector/formSelector.tsx
@@ -1,6 +1,7 @@
 import { FC, Fragment, Suspense, lazy } from 'react';
 
 import { SubmitFieldProps } from '../../components/actions/submit/submit.types';
+import { RadioGroupProps } from '../../components/fields/radio/radio.types';
 import { TextProps } from '../../components/fields/text/text.types';
 import { FormSelectorProps } from './formSelector.types';
 
@@ -35,6 +36,17 @@ const FormSelector: FC<FormSelectorProps> = ({
       return (
         <Suspense key={fieldProps.id} fallback={<SubmitLoading {...loading} />}>
           <SelectedComponent {...(fieldProps as SubmitFieldProps)} />
+        </Suspense>
+      );
+
+    case 'radio':
+      SelectedComponent = lazy(
+        () => import('../../components/fields/radio/radioGroup')
+      );
+
+      return (
+        <Suspense key={fieldProps.id} fallback={<SubmitLoading {...loading} />}>
+          <SelectedComponent {...(fieldProps as RadioGroupProps)} />
         </Suspense>
       );
 


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!
-->

Closes #44  <!-- Github issue # here -->

## 📝 Description

<!--  Add a brief description -->

## ⛳️ Current behavior (updates)

<!--  Please describe the current behavior that you are modifying -->

## 🚀 New behavior

<!--  Please describe the behavior or changes this PR adds -->

## 💣 Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path for existing NextUI users. -->

## 📝 Additional Information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced radio input functionality in forms.
  - Added `RadioGroup` component to manage and display radio options.
  - Enhanced form selector to support radio input fields.

- **Improvements**
  - Updated form input labels for consistency.
  - Enhanced configurability and functionality of radio components with new type definitions.

- **Removals**
  - Removed nested checkbox objects under `form-checkbox-1` for better form management.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->