### PR TITLE
Feat(form)/password 49

### DIFF
--- a/apps/docs/src/app/app.tsx
+++ b/apps/docs/src/app/app.tsx
@@ -219,6 +219,16 @@ export function App() {
         ],
       },
     },
+    {
+      id: 'form-password-1',
+      groupType: 'form',
+      type: 'password',
+      props: {
+        id: 'password-one',
+        formId: '20',
+        label: 'Password Field (Form Id: 20)',
+      },
+    },
   ];
 
   const [tabs, setTabs] = useState<TabData[]>([

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "@changesets/cli": "^2.27.1",
         "@emotion/react": "^11.11.4",
         "@emotion/styled": "^11.11.0",
+        "@mui/icons-material": "^5.15.21",
         "@mui/lab": "^5.0.0-alpha.167",
         "@mui/material": "^5.15.11",
         "react": "18.2.0",
@@ -3836,6 +3837,10 @@
       "resolved": "packages/components/grid",
       "link": true
     },
+    "node_modules/@mui-builder/tab": {
+      "resolved": "packages/tab",
+      "link": true
+    },
     "node_modules/@mui-builder/utils": {
       "resolved": "packages/utils",
       "link": true
@@ -3878,6 +3883,31 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/mui-org"
+      }
+    },
+    "node_modules/@mui/icons-material": {
+      "version": "5.15.21",
+      "resolved": "https://registry.npmjs.org/@mui/icons-material/-/icons-material-5.15.21.tgz",
+      "integrity": "sha512-yqkq1MbdkmX5ZHyvZTBuAaA6RkvoqkoAgwBSx9Oh0L0jAfj9T/Ih/NhMNjkl8PWVSonjfDUkKroBnjRyo/1M9Q==",
+      "dependencies": {
+        "@babel/runtime": "^7.23.9"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mui-org"
+      },
+      "peerDependencies": {
+        "@mui/material": "^5.0.0",
+        "@types/react": "^17.0.0 || ^18.0.0",
+        "react": "^17.0.0 || ^18.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
       }
     },
     "node_modules/@mui/lab": {
@@ -20911,12 +20941,17 @@
       "version": "0.0.7",
       "dependencies": {
         "@mui-builder/form": "*",
-        "@mui-builder/grid": "*"
+        "@mui-builder/grid": "*",
+        "@mui-builder/utils": "*"
       },
       "peerDependencies": {
         "react": "18.2.0",
         "react-dom": "18.2.0"
       }
+    },
+    "packages/tab": {
+      "name": "@mui-builder/tab",
+      "version": "0.0.4"
     },
     "packages/utils": {
       "name": "@mui-builder/utils",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "@changesets/cli": "^2.27.1",
     "@emotion/react": "^11.11.4",
     "@emotion/styled": "^11.11.0",
+    "@mui/icons-material": "^5.15.21",
     "@mui/lab": "^5.0.0-alpha.167",
     "@mui/material": "^5.15.11",
     "react": "18.2.0",

--- a/packages/core/src/modules/form/src/components/fields/password/password.loading.tsx
+++ b/packages/core/src/modules/form/src/components/fields/password/password.loading.tsx
@@ -1,0 +1,13 @@
+import { Skeleton } from '@mui/material';
+
+import { LoadingProps } from '@mui-builder/types/configs.type';
+
+import usePasswordLoading from './usePassword.loading';
+
+const PasswordLoading = (props: LoadingProps) => {
+  const { getTextLoadingProps } = usePasswordLoading(props);
+
+  return <Skeleton {...getTextLoadingProps()} />;
+};
+
+export default PasswordLoading;

--- a/packages/core/src/modules/form/src/components/fields/password/password.tsx
+++ b/packages/core/src/modules/form/src/components/fields/password/password.tsx
@@ -1,11 +1,11 @@
 import { FC } from 'react';
 
+import { Visibility, VisibilityOff } from '@mui/icons-material';
 import { IconButton, InputAdornment, TextField } from '@mui/material';
 
 import { PasswordProps } from './password.types';
 
 import usePassword from './usePassword';
-import { Visibility, VisibilityOff } from '@mui/icons-material';
 
 const Password: FC<PasswordProps> = (props) => {
   const {

--- a/packages/core/src/modules/form/src/components/fields/password/password.tsx
+++ b/packages/core/src/modules/form/src/components/fields/password/password.tsx
@@ -1,0 +1,38 @@
+import { FC } from 'react';
+
+import { IconButton, InputAdornment, TextField } from '@mui/material';
+
+import { PasswordProps } from './password.types';
+
+import usePassword from './usePassword';
+import { Visibility, VisibilityOff } from '@mui/icons-material';
+
+const Password: FC<PasswordProps> = (props) => {
+  const {
+    getFieldProps,
+    show,
+    getInputAdornmentProps,
+    getIconButtonProps,
+    showPassword,
+  } = usePassword(props);
+
+  if (show)
+    return (
+      <TextField
+        {...getFieldProps()}
+        InputProps={{
+          endAdornment: (
+            <InputAdornment {...getInputAdornmentProps()}>
+              <IconButton {...getIconButtonProps()}>
+                {showPassword ? <VisibilityOff /> : <Visibility />}
+              </IconButton>
+            </InputAdornment>
+          ),
+        }}
+      />
+    );
+
+  return null;
+};
+
+export default Password;

--- a/packages/core/src/modules/form/src/components/fields/password/password.types.ts
+++ b/packages/core/src/modules/form/src/components/fields/password/password.types.ts
@@ -1,0 +1,18 @@
+import { TextFieldProps } from '@mui/material';
+
+import { Api } from '@mui-builder/types/api.types';
+import { Script } from '@mui-builder/types/script.types';
+
+import { Dependesies, FormId, Id } from '../../../types/public.types';
+import { Rule } from '../../../types/validation.types';
+
+export type PasswordProps = TextFieldProps & {
+  id: Id;
+  formId: FormId;
+  script?: Script;
+  dependesies?: Dependesies;
+  propsController?: Record<string, any>;
+  api?: Api;
+  rule?: Rule;
+  show?: boolean;
+};

--- a/packages/core/src/modules/form/src/components/fields/password/usePassword.loading.ts
+++ b/packages/core/src/modules/form/src/components/fields/password/usePassword.loading.ts
@@ -1,0 +1,22 @@
+import { LoadingProps } from '@mui-builder/types/configs.type';
+
+const usePasswordLoading = (props: LoadingProps) => {
+  const { animation = 'wave', sx, ...otherProps } = props;
+
+  const getPasswordLoadingProps = () => ({
+    sx: {
+      display: 'inline-block',
+      transform: 'unset',
+      width: '255px',
+      height: '56px',
+      mx: 0.5,
+      ...sx,
+    },
+    animation,
+    ...otherProps,
+  });
+
+  return { getTextLoadingProps: getPasswordLoadingProps };
+};
+
+export default usePasswordLoading;

--- a/packages/core/src/modules/form/src/components/fields/password/usePassword.ts
+++ b/packages/core/src/modules/form/src/components/fields/password/usePassword.ts
@@ -1,0 +1,107 @@
+import { useState } from 'react';
+import { useController, useWatch } from 'react-hook-form';
+
+import { IconButtonProps, InputAdornmentProps } from '@mui/material';
+
+import useQueryBuilder from '@mui-builder/utils/useQueryBuilder/useQueryBuilder';
+import UseScript from '@mui-builder/utils/useScript/useScript';
+
+import axios from 'axios';
+
+import { PasswordProps } from './password.types';
+
+import useForms from '../../../hooks/useForms/useForms';
+import usePropsController from '../../../hooks/usePropsController/usePropsController';
+import useRule from '../../../hooks/useRule/useRule';
+
+const UsePassword = (props: PasswordProps) => {
+  const {
+    formId,
+    script,
+    api,
+    show = true,
+    dependesies,
+    helperText,
+    defaultValue,
+    ...textFieldProps
+  } = props;
+  const { configs, queries } = api || {};
+
+  const { forms } = useForms();
+  const formMethod = forms?.[formId];
+  const { setProps, propsController } = usePropsController();
+
+  const newProps = propsController?.[textFieldProps?.id] || {};
+
+  // eye icon
+  const [showPassword, setShowPassword] = useState(false);
+
+  const handleClickShowPassword = () => {
+    setShowPassword(!showPassword);
+  };
+
+  // Handle Script
+  const { scriptResult } = UseScript({
+    script,
+    formMethod,
+    forms,
+    formId,
+    setProps,
+  });
+
+  // Handle Wtach Fields
+  useWatch({
+    control: formMethod.control,
+    name: dependesies ?? [],
+  });
+
+  // API Call
+  useQueryBuilder({
+    apiInstance: axios,
+    apiConfigs: configs ?? {},
+    apiQuery: queries ?? {},
+    formMethod,
+    formId,
+    forms,
+  });
+
+  // Controller
+  const {
+    field,
+    formState: { errors },
+  } = useController({
+    name: textFieldProps.id,
+    control: formMethod.control,
+    disabled: textFieldProps.disabled,
+    rules: useRule(textFieldProps?.rule),
+    defaultValue,
+  });
+
+  const error = errors?.[textFieldProps.id];
+
+  // Props
+  const getFieldProps = () => ({
+    ...field,
+    ...textFieldProps,
+    helperText: error?.message ?? helperText,
+    error: !!error,
+    value: field.value ?? '',
+    ...scriptResult,
+    ...newProps,
+    type: showPassword ? 'text' : 'password',
+  });
+
+  const getInputAdornmentProps = (): InputAdornmentProps => ({
+    position: 'end',
+  });
+
+  const getIconButtonProps = (): IconButtonProps => ({
+    'aria-label': 'toggle password visibility',
+    onClick: handleClickShowPassword,
+    edge: 'end',
+  });
+
+  return { getFieldProps, show, getInputAdornmentProps, getIconButtonProps, showPassword };
+};
+
+export default UsePassword;

--- a/packages/core/src/modules/form/src/types/public.types.ts
+++ b/packages/core/src/modules/form/src/types/public.types.ts
@@ -19,7 +19,8 @@ export type FormTypes =
   | 'field-text'
   | 'action-submit'
   | 'auto-complete'
-  | 'checkbox';
+  | 'checkbox'
+  | 'password';
 
 export type FieldProps =
   | TextProps

--- a/packages/core/src/modules/form/src/utils/selector/formSelector.tsx
+++ b/packages/core/src/modules/form/src/utils/selector/formSelector.tsx
@@ -11,6 +11,8 @@ import { FormSelectorProps } from './formSelector.types';
 
 import SubmitLoading from '../../components/actions/submit/submit.loading';
 import TextLoading from '../../components/fields/text/text.loading';
+import PasswordLoading from '../../components/fields/password/password.loading';
+import { PasswordProps } from '../../components/fields/password/password.types';
 
 const FormSelector: FC<FormSelectorProps> = ({
   fieldType,
@@ -67,6 +69,17 @@ const FormSelector: FC<FormSelectorProps> = ({
         </Suspense>
       );
 
+      case 'password':
+        SelectedComponent = lazy(
+          () => import('../../components/fields/password/password')
+        );
+  
+        return (
+          <Suspense key={fieldProps.id} fallback={<PasswordLoading {...loading} />}>
+            <SelectedComponent {...(fieldProps as PasswordProps)} />
+          </Suspense>
+        );
+  
     default:
       SelectedComponent = Fragment;
 

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -10,7 +10,7 @@
   "include": [],
   "references": [
     {
-      "path": "./tsconfig.lib.json"
+      "path": "./tsconfig.lib.json" 
     }
   ],
   "extends": "../../tsconfig.base.json"


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!
-->

Closes #49  <!-- Github issue # here -->

## 📝 Description

<!--  Add a brief description -->

## ⛳️ Current behavior (updates)

<!--  Please describe the current behavior that you are modifying -->

## 🚀 New behavior

<!--  Please describe the behavior or changes this PR adds -->

## 💣 Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path for existing NextUI users. -->

## 📝 Additional Information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a password field component with visibility toggle in form inputs.
  - Added loading skeleton for password fields to enhance user experience during data fetches.

- **Dependencies**
  - Added `@mui/icons-material` package to the project dependencies.

- **Enhancements**
  - Expanded the form field types to include 'password' in addition to existing types.

- **Performance Improvements**
  - Implemented lazy loading for password components to improve form loading times.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->